### PR TITLE
update logging

### DIFF
--- a/driveslow/fetcher.py
+++ b/driveslow/fetcher.py
@@ -118,21 +118,19 @@ class Fetcher:
         self.setup_logging()
 
     def setup_logging(self):
-        log_path = self.store.base_dir / "fetcher.log"
-
-        # Configure standard logging
+        # Configure standard logging to stdout only
         logging.basicConfig(
             level=logging.INFO,
             format="%(message)s",
-            handlers=[logging.FileHandler(log_path), logging.StreamHandler()],
+            handlers=[logging.StreamHandler()],
         )
 
-        # Configure structlog
+        # Configure structlog with console renderer
         structlog.configure(
             processors=[
                 structlog.stdlib.add_log_level,
                 structlog.processors.TimeStamper(fmt="iso"),
-                structlog.processors.JSONRenderer(),
+                structlog.dev.ConsoleRenderer(),
             ],
             wrapper_class=structlog.stdlib.BoundLogger,
             context_class=dict,

--- a/driveslow/fetcher.py
+++ b/driveslow/fetcher.py
@@ -115,29 +115,6 @@ class Fetcher:
         self.urls = urls
         self.interval = interval
         self.store = ContentStore(name=name, base_dir=output_dir, extension=extension)
-        self.setup_logging()
-
-    def setup_logging(self):
-        # Configure standard logging to stdout only
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-
-        # Configure structlog with console renderer
-        structlog.configure(
-            processors=[
-                structlog.stdlib.add_log_level,
-                structlog.processors.TimeStamper(fmt="iso"),
-                structlog.dev.ConsoleRenderer(),
-            ],
-            wrapper_class=structlog.stdlib.BoundLogger,
-            context_class=dict,
-            logger_factory=structlog.stdlib.LoggerFactory(),
-            cache_logger_on_first_use=True,
-        )
-
         self.logger = structlog.get_logger(self.name)
 
     async def fetch_url(self, session: aiohttp.ClientSession, url: str):
@@ -201,6 +178,25 @@ async def run_fetchers(fetchers):
 
 
 def main():
+    # Configure logging once for the entire application
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(message)s",
+        handlers=[logging.StreamHandler()],
+    )
+
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.dev.ConsoleRenderer(),
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
     output_dir = os.getenv("OUTPUT_DIR", "./output")
     interval = int(os.getenv("FETCH_INTERVAL", "15"))
 

--- a/driveslow/fetcher.py
+++ b/driveslow/fetcher.py
@@ -12,6 +12,7 @@ import os
 import requests
 from urllib.parse import urlparse
 
+logger = structlog.get_logger()
 
 class ContentStore:
     def __init__(self, name: str, base_dir: str = "/output", extension: str = ".json"):
@@ -199,6 +200,7 @@ def main():
 
     output_dir = os.getenv("OUTPUT_DIR", "./output")
     interval = int(os.getenv("FETCH_INTERVAL", "15"))
+    logger.info("starting up", output_dir=output_dir, interval=interval)
 
     # Example of using multiple named fetchers
     cc_urls = [
@@ -215,6 +217,7 @@ def main():
         ),  # roadside weather
     ]
     # something special for cctv
+    logger.info("getting cctv list")
     resp = requests.get("https://cwwp2.dot.ca.gov/data/d3/cctv/cctvStatusD03.json")
     cctv = resp.json()
     cams = cctv.get("data")
@@ -234,6 +237,7 @@ def main():
                 )
             )
 
+    logger.info("starting fetchers")
     try:
         # Run all fetchers concurrently
         asyncio.run(run_fetchers(fetchers))

--- a/driveslow/fetcher.py
+++ b/driveslow/fetcher.py
@@ -5,6 +5,7 @@ import hashlib
 from datetime import datetime
 from pathlib import Path
 import structlog
+import logging
 import time
 import aiosqlite
 import os
@@ -119,19 +120,23 @@ class Fetcher:
     def setup_logging(self):
         log_path = self.store.base_dir / "fetcher.log"
 
+        # Configure standard logging
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(message)s",
+            handlers=[logging.FileHandler(log_path), logging.StreamHandler()],
+        )
+
         # Configure structlog
         structlog.configure(
             processors=[
-                structlog.contextvars.merge_contextvars,
-                structlog.processors.add_log_level,
+                structlog.stdlib.add_log_level,
                 structlog.processors.TimeStamper(fmt="iso"),
-                structlog.processors.StackInfoRenderer(),
-                structlog.processors.format_exc_info,
                 structlog.processors.JSONRenderer(),
             ],
-            wrapper_class=structlog.make_filtering_bound_logger(structlog.INFO),
+            wrapper_class=structlog.stdlib.BoundLogger,
             context_class=dict,
-            logger_factory=structlog.PrintLoggerFactory(file=open(log_path, "a")),
+            logger_factory=structlog.stdlib.LoggerFactory(),
             cache_logger_on_first_use=True,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "aiohttp>=3.13.3",
     "aiosqlite>=0.22.1",
     "requests>=2.32.5",
+    "structlog>=25.1.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -201,6 +201,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "requests" },
+    { name = "structlog" },
 ]
 
 [package.metadata]
@@ -208,6 +209,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "structlog", specifier = ">=25.1.0" },
 ]
 
 [[package]]
@@ -504,6 +506,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add structlog dependency to pyproject.toml
- Configure structlog with JSON renderer and ISO timestamps
- Convert all logging calls from f-strings to key-value logging
- Update setup_logging to use structlog processors
- Adds some more loggers + rearranges setting up logger into the main function rather than each fetcher

Resolves #8 